### PR TITLE
To string

### DIFF
--- a/src/cpc_sketch_c_adapter.cpp
+++ b/src/cpc_sketch_c_adapter.cpp
@@ -82,13 +82,17 @@ Datum* cpc_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_st
   pg_unreachable();
 }
 
-void cpc_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
+char* cpc_sketch_to_string(const void* sketchptr) {
   try {
     auto str = static_cast<const cpc_sketch_pg*>(sketchptr)->to_string();
-    snprintf(buffer, length, "%s", str.c_str());
+    const size_t len = str.length() + 1;
+    char* buffer = (char*) palloc(len);
+    strncpy(buffer, str.c_str(), len);
+    return buffer;
   } catch (std::exception& e) {
     pg_error(e.what());
   }
+  pg_unreachable();
 }
 
 struct ptr_with_size cpc_sketch_serialize(const void* sketchptr, unsigned header_size) {

--- a/src/cpc_sketch_c_adapter.cpp
+++ b/src/cpc_sketch_c_adapter.cpp
@@ -21,8 +21,6 @@
 #include "allocator.h"
 #include "postgres_h_substitute.h"
 
-#include <sstream>
-
 #include <cpc_sketch.hpp>
 #include <cpc_union.hpp>
 
@@ -86,9 +84,8 @@ Datum* cpc_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_st
 
 void cpc_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
   try {
-    std::stringstream s;
-    static_cast<const cpc_sketch_pg*>(sketchptr)->to_stream(s);
-    snprintf(buffer, length, "%s", s.str().c_str());
+    auto str = static_cast<const cpc_sketch_pg*>(sketchptr)->to_string();
+    snprintf(buffer, length, "%s", str.c_str());
   } catch (std::exception& e) {
     pg_error(e.what());
   }

--- a/src/cpc_sketch_c_adapter.h
+++ b/src/cpc_sketch_c_adapter.h
@@ -34,7 +34,7 @@ void cpc_sketch_update(void* sketchptr, const void* data, unsigned length);
 void cpc_sketch_merge(void* sketchptr1, const void* sketchptr2);
 double cpc_sketch_get_estimate(const void* sketchptr);
 void** cpc_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_std_devs);
-void cpc_sketch_to_string(const void* sketchptr, char* buffer, unsigned length);
+char* cpc_sketch_to_string(const void* sketchptr);
 
 struct ptr_with_size {
   void* ptr;

--- a/src/cpc_sketch_pg_functions.c
+++ b/src/cpc_sketch_pg_functions.c
@@ -143,10 +143,10 @@ Datum pg_cpc_sketch_get_estimate_and_bounds(PG_FUNCTION_ARGS) {
 Datum pg_cpc_sketch_to_string(PG_FUNCTION_ARGS) {
   const bytea* bytes_in;
   void* sketchptr;
-  char str[1024];
+  char* str;
   bytes_in = PG_GETARG_BYTEA_P(0);
   sketchptr = cpc_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
-  cpc_sketch_to_string(sketchptr, str, 1024);
+  str = cpc_sketch_to_string(sketchptr);
   cpc_sketch_delete(sketchptr);
   PG_RETURN_TEXT_P(cstring_to_text(str));
 }

--- a/src/frequent_strings_sketch_c_adapter.cpp
+++ b/src/frequent_strings_sketch_c_adapter.cpp
@@ -116,7 +116,7 @@ void frequent_strings_sketch_merge(void* sketchptr1, const void* sketchptr2) {
 char* frequent_strings_sketch_to_string(const void* sketchptr, bool print_items) {
   try {
     auto str = static_cast<const frequent_strings_sketch*>(sketchptr)->to_string(print_items);
-    const unsigned len = (unsigned) str.length() + 1;
+    const size_t len = str.length() + 1;
     char* buffer = (char*) palloc(len);
     strncpy(buffer, str.c_str(), len);
     return buffer;

--- a/src/frequent_strings_sketch_c_adapter.cpp
+++ b/src/frequent_strings_sketch_c_adapter.cpp
@@ -22,7 +22,6 @@
 #include "postgres_h_substitute.h"
 
 #include <string>
-#include <sstream>
 
 #include <frequent_items_sketch.hpp>
 
@@ -116,11 +115,10 @@ void frequent_strings_sketch_merge(void* sketchptr1, const void* sketchptr2) {
 
 char* frequent_strings_sketch_to_string(const void* sketchptr, bool print_items) {
   try {
-    std::stringstream s;
-    static_cast<const frequent_strings_sketch*>(sketchptr)->to_stream(s, print_items);
-    const unsigned len = (unsigned) s.tellp() + 1;
+    auto str = static_cast<const frequent_strings_sketch*>(sketchptr)->to_string(print_items);
+    const unsigned len = (unsigned) str.length() + 1;
     char* buffer = (char*) palloc(len);
-    strncpy(buffer, s.str().c_str(), len);
+    strncpy(buffer, str.c_str(), len);
     return buffer;
   } catch (std::exception& e) {
     pg_error(e.what());

--- a/src/hll_sketch_c_adapter.cpp
+++ b/src/hll_sketch_c_adapter.cpp
@@ -86,13 +86,17 @@ Datum* hll_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_st
   pg_unreachable();
 }
 
-void hll_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
+char* hll_sketch_to_string(const void* sketchptr) {
   try {
     auto str = static_cast<const hll_sketch_pg*>(sketchptr)->to_string();
-    snprintf(buffer, length, "%s", str.c_str());
+    const size_t len = str.length() + 1;
+    char* buffer = (char*) palloc(len);
+    strncpy(buffer, str.c_str(), len);
+    return buffer;
   } catch (std::exception& e) {
     pg_error(e.what());
   }
+  pg_unreachable();
 }
 
 ptr_with_size hll_sketch_serialize(const void* sketchptr, unsigned header_size) {

--- a/src/hll_sketch_c_adapter.cpp
+++ b/src/hll_sketch_c_adapter.cpp
@@ -21,8 +21,6 @@
 #include "allocator.h"
 #include "postgres_h_substitute.h"
 
-#include <sstream>
-
 #include <hll.hpp>
 
 typedef datasketches::hll_sketch_alloc<palloc_allocator<char>> hll_sketch_pg;
@@ -90,9 +88,8 @@ Datum* hll_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_st
 
 void hll_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
   try {
-    std::stringstream s;
-    static_cast<const hll_sketch_pg*>(sketchptr)->to_string(s);
-    snprintf(buffer, length, "%s", s.str().c_str());
+    auto str = static_cast<const hll_sketch_pg*>(sketchptr)->to_string();
+    snprintf(buffer, length, "%s", str.c_str());
   } catch (std::exception& e) {
     pg_error(e.what());
   }

--- a/src/hll_sketch_c_adapter.h
+++ b/src/hll_sketch_c_adapter.h
@@ -32,7 +32,7 @@ void hll_sketch_update(void* sketchptr, const void* data, unsigned length);
 void hll_sketch_merge(void* sketchptr1, const void* sketchptr2);
 double hll_sketch_get_estimate(const void* sketchptr);
 void** hll_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_std_devs);
-void hll_sketch_to_string(const void* sketchptr, char* buffer, unsigned length);
+char* hll_sketch_to_string(const void* sketchptr);
 
 struct ptr_with_size {
   void* ptr;

--- a/src/hll_sketch_pg_functions.c
+++ b/src/hll_sketch_pg_functions.c
@@ -153,10 +153,10 @@ Datum pg_hll_sketch_get_estimate_and_bounds(PG_FUNCTION_ARGS) {
 Datum pg_hll_sketch_to_string(PG_FUNCTION_ARGS) {
   const bytea* bytes_in;
   void* sketchptr;
-  char str[1024];
+  char* str;
   bytes_in = PG_GETARG_BYTEA_P(0);
   sketchptr = hll_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
-  hll_sketch_to_string(sketchptr, str, 1024);
+  str = hll_sketch_to_string(sketchptr);
   hll_sketch_delete(sketchptr);
   PG_RETURN_TEXT_P(cstring_to_text(str));
 }

--- a/src/kll_float_sketch_c_adapter.cpp
+++ b/src/kll_float_sketch_c_adapter.cpp
@@ -21,8 +21,6 @@
 #include "allocator.h"
 #include "postgres_h_substitute.h"
 
-#include <sstream>
-
 #include <kll_sketch.hpp>
 
 typedef datasketches::kll_sketch<float, std::less<float>, datasketches::serde<float>, palloc_allocator<float>> kll_float_sketch;
@@ -90,9 +88,8 @@ unsigned long long kll_float_sketch_get_n(const void* sketchptr) {
 
 void kll_float_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
   try {
-    std::stringstream s;
-    static_cast<const kll_float_sketch*>(sketchptr)->to_stream(s);
-    snprintf(buffer, length, "%s", s.str().c_str());
+    auto str = static_cast<const kll_float_sketch*>(sketchptr)->to_string();
+    snprintf(buffer, length, "%s", str.c_str());
   } catch (std::exception& e) {
     pg_error(e.what());
   }

--- a/src/kll_float_sketch_c_adapter.cpp
+++ b/src/kll_float_sketch_c_adapter.cpp
@@ -86,13 +86,17 @@ unsigned long long kll_float_sketch_get_n(const void* sketchptr) {
   pg_unreachable();
 }
 
-void kll_float_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
+char* kll_float_sketch_to_string(const void* sketchptr) {
   try {
     auto str = static_cast<const kll_float_sketch*>(sketchptr)->to_string();
-    snprintf(buffer, length, "%s", str.c_str());
+    const size_t len = str.length() + 1;
+    char* buffer = (char*) palloc(len);
+    strncpy(buffer, str.c_str(), len);
+    return buffer;
   } catch (std::exception& e) {
     pg_error(e.what());
   }
+  pg_unreachable();
 }
 
 ptr_with_size kll_float_sketch_serialize(const void* sketchptr, unsigned header_size) {

--- a/src/kll_float_sketch_c_adapter.h
+++ b/src/kll_float_sketch_c_adapter.h
@@ -32,7 +32,7 @@ void kll_float_sketch_merge(void* sketchptr1, const void* sketchptr2);
 double kll_float_sketch_get_rank(const void* sketchptr, float value);
 float kll_float_sketch_get_quantile(const void* sketchptr, double rank);
 unsigned long long kll_float_sketch_get_n(const void* sketchptr);
-void kll_float_sketch_to_string(const void* sketchptr, char* buffer, unsigned length);
+char* kll_float_sketch_to_string(const void* sketchptr);
 
 struct ptr_with_size {
   void* ptr;

--- a/src/kll_float_sketch_pg_functions.c
+++ b/src/kll_float_sketch_pg_functions.c
@@ -132,10 +132,10 @@ Datum pg_kll_float_sketch_get_n(PG_FUNCTION_ARGS) {
 Datum pg_kll_float_sketch_to_string(PG_FUNCTION_ARGS) {
   const bytea* bytes_in;
   void* sketchptr;
-  char str[1024];
+  char* str;
   bytes_in = PG_GETARG_BYTEA_P(0);
   sketchptr = kll_float_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
-  kll_float_sketch_to_string(sketchptr, str, 1024);
+  str = kll_float_sketch_to_string(sketchptr);
   kll_float_sketch_delete(sketchptr);
   PG_RETURN_TEXT_P(cstring_to_text(str));
 }

--- a/src/theta_sketch_c_adapter.cpp
+++ b/src/theta_sketch_c_adapter.cpp
@@ -21,8 +21,6 @@
 #include "allocator.h"
 #include "postgres_h_substitute.h"
 
-#include <sstream>
-
 #include <theta_sketch.hpp>
 #include <theta_union.hpp>
 #include <theta_intersection.hpp>
@@ -115,9 +113,8 @@ Datum* theta_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_
 
 void theta_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
   try {
-    std::stringstream s;
-    static_cast<const theta_sketch_pg*>(sketchptr)->to_stream(s);
-    snprintf(buffer, length, "%s", s.str().c_str());
+    auto str = static_cast<const theta_sketch_pg*>(sketchptr)->to_string();
+    snprintf(buffer, length, "%s", str.c_str());
   } catch (std::exception& e) {
     pg_error(e.what());
   }

--- a/src/theta_sketch_c_adapter.cpp
+++ b/src/theta_sketch_c_adapter.cpp
@@ -111,13 +111,17 @@ Datum* theta_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_
   pg_unreachable();
 }
 
-void theta_sketch_to_string(const void* sketchptr, char* buffer, unsigned length) {
+char* theta_sketch_to_string(const void* sketchptr) {
   try {
     auto str = static_cast<const theta_sketch_pg*>(sketchptr)->to_string();
-    snprintf(buffer, length, "%s", str.c_str());
+    const size_t len = str.length() + 1;
+    char* buffer = (char*) palloc(len);
+    strncpy(buffer, str.c_str(), len);
+    return buffer;
   } catch (std::exception& e) {
     pg_error(e.what());
   }
+  pg_unreachable();
 }
 
 ptr_with_size theta_sketch_serialize(const void* sketchptr, unsigned header_size) {

--- a/src/theta_sketch_c_adapter.h
+++ b/src/theta_sketch_c_adapter.h
@@ -34,7 +34,7 @@ void* theta_sketch_compact(void* sketchptr);
 void theta_sketch_union(void* sketchptr1, const void* sketchptr2);
 double theta_sketch_get_estimate(const void* sketchptr);
 void** theta_sketch_get_estimate_and_bounds(const void* sketchptr, unsigned num_std_devs);
-void theta_sketch_to_string(const void* sketchptr, char* buffer, unsigned length);
+char* theta_sketch_to_string(const void* sketchptr);
 
 struct ptr_with_size {
   void* ptr;

--- a/src/theta_sketch_pg_functions.c
+++ b/src/theta_sketch_pg_functions.c
@@ -151,10 +151,10 @@ Datum pg_theta_sketch_get_estimate_and_bounds(PG_FUNCTION_ARGS) {
 Datum pg_theta_sketch_to_string(PG_FUNCTION_ARGS) {
   const bytea* bytes_in;
   void* sketchptr;
-  char str[1024];
+  char* str;
   bytes_in = PG_GETARG_BYTEA_P(0);
   sketchptr = theta_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
-  theta_sketch_to_string(sketchptr, str, 1024);
+  str = theta_sketch_to_string(sketchptr);
   theta_sketch_delete(sketchptr);
   PG_RETURN_TEXT_P(cstring_to_text(str));
 }


### PR DESCRIPTION
Compatibility with the current core library.
Moved allocation to the C adapter where the exact size is known as opposed to reserving an excessive amount.