### PR TITLE
Use Boost 1.75.0

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,7 +22,9 @@ jobs:
     - name: download Boost
       run: make boost
     - name: install PostgreSQL
-      run: sudo apt-get -y install postgresql-14 postgresql-client-14 postgresql-server-dev-14 libpq-dev
+      run: |
+        sudo apt update
+        sudo apt -y install postgresql-14 postgresql-client-14 postgresql-server-dev-14 libpq-dev
     - name: make
       run: make
     - name: install

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CORE = datasketches-cpp
 
 # assume a dir or link named "boost" in the current dir
 BOOST = boost
-BOOST_VER = 1.82.0
+BOOST_VER = 1.75.0
 BOOST_FILE = boost_$(subst .,_,$(BOOST_VER))
 BOOST_URL = https://boostorg.jfrog.io/artifactory/main/release/$(BOOST_VER)/source/$(BOOST_FILE).zip
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ If you are interested in making contributions to this site please see our
 ## This extension currently supports the following sketches:
 
 - CPC (Compressed Probabilistic Counting) sketch - very compact (smaller than HLL when serialized) distinct-counting sketch
-- Theta sketch - distinct counting with set operations (union, intersection, a-not-b)
 - HLL sketch - very compact distinct-counting sketch based on HyperLogLog algorithm
-- KLL float quantiles sketch - for estimating distributions: quantile, rank, PMF (histogram), CDF
+- Theta sketch - distinct counting with set operations (union, intersection, a-not-b)
+- Array Of Doubles (AOD) sketch - a kind of Tuple sketch with array of double values associated with each key
+- KLL (float and double) quantiles sketch - for estimating distributions: quantile, rank, PMF (histogram), CDF
+- Quantiles sketch (inferior to KLL, for long-term support of data sets)
 - Frequent strings sketch - capture the heaviest items (strings) by count or by some other weight
 
 ## Building this PostgreSQL Extension Requires 4 Dependencies
 
 * C++11
-* Boost version 1.76.0 we know this works, older and newer may work as well
+* Boost version 1.75.0 we know this works, older and newer may work as well
 * PostgreSQL database versions 9.6 and higher
 * [DataSketches *C++/Python Core*](https://github.com/apache/datasketches-cpp) version 4.1.0 or later
 
@@ -93,7 +95,7 @@ both of which can be obtained from
 From the command line at the PGXN installed root or the root of the C++ PostgreSQL Adaptor run:
 
 * *make*
-* *sudo make install*  #sudo may not be required depending on how PSQL was installed
+* *sudo make install*  #sudo may not be required depending on how PostgreSQL was installed
 
 NOTE: On MacOSX Mojave, if you see a warning similar to this:
 

--- a/package.sh
+++ b/package.sh
@@ -34,11 +34,6 @@ fi
 # version of datasketches-cpp core library to include
 CORETAG=4.1.0
 
-# boost version to include
-BOOSTVER=1.76.0
-BOOSTNAME=boost_${BOOSTVER//./_}
-BOOSTURL=https://boostorg.jfrog.io/artifactory/main/release/$BOOSTVER/source/$BOOSTNAME.zip
-
 DST=datasketches-$VER
 
 PGARCH=postgresql-$VER.zip
@@ -51,7 +46,6 @@ git archive --format zip --prefix=$DST/ --output $PGARCH $TAG
 cd ../datasketches-cpp
 git archive --format zip --output ../datasketches-postgresql/$COREARCH $CORETAG
 cd ../datasketches-postgresql
-#wget $BOOSTURL
 
 unzip $PGARCH
 COREDIR=$DST/datasketches-cpp
@@ -62,10 +56,7 @@ unzip $COREARCH -d $COREDIR
 rm $COREDIR/README.md
 rm $COREDIR/*/README.md
 
-#unzip $BOOSTNAME.zip
-#mv boost_${BOOSTVER//./_}/boost $DST
-
 zip -r $DST.zip $DST
 
-rm -f $PGARCH $COREARCH $BOOSTNAME.zip
-rm -rf $DST $BOOSTNAME
+rm -f $PGARCH $COREARCH
+rm -rf $DST


### PR DESCRIPTION
Boost 1.75.0 still works with GCC 4.8.5 (standard on RHEL7).
Updated the list of sketches.
Removed commented-out lines to add Boost to PGXN package (the package exceeds the allowed size)