### PR TITLE
Fixes missing VARDATA symbol in PG16

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -21,6 +21,7 @@
 #include <utils/builtins.h>
 
 #include "base64.h"
+#include "varatt.h"
 
 PG_MODULE_MAGIC;
 

--- a/src/common.c
+++ b/src/common.c
@@ -21,7 +21,12 @@
 #include <utils/builtins.h>
 
 #include "base64.h"
+
+// Since version 16 of PG, all functionality for variable-length
+// data was moved from postgres.h into the new file varatt.h
+#if PG_VERSION_NUM >= 160000
 #include "varatt.h"
+#endif
 
 PG_MODULE_MAGIC;
 


### PR DESCRIPTION
When trying to create datasketches extension in PG16, I get an error saying that there's a missing symbol (VARDATA). Adding an include of varatt.h fixes this issue.