### PR TITLE
Add get_min_item and get_max_item functions for kll float and double sketches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .project
 .settings/
 
+# CLion project files
+.idea
+
 # Visual Studio Code
 .vscode/
 

--- a/sql/datasketches_kll_double_sketch.sql
+++ b/sql/datasketches_kll_double_sketch.sql
@@ -118,6 +118,14 @@ CREATE OR REPLACE FUNCTION kll_double_sketch_get_n(kll_double_sketch) RETURNS bi
     AS '$libdir/datasketches', 'pg_kll_double_sketch_get_n'
     LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION kll_double_sketch_get_max_item(kll_double_sketch) RETURNS double precision
+    AS '$libdir/datasketches', 'pg_kll_double_sketch_get_max_item'
+    LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION kll_double_sketch_get_min_item(kll_double_sketch) RETURNS double precision
+    AS '$libdir/datasketches', 'pg_kll_double_sketch_get_min_item'
+    LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION kll_double_sketch_to_string(kll_double_sketch) RETURNS TEXT
     AS '$libdir/datasketches', 'pg_kll_double_sketch_to_string'
     LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;

--- a/sql/datasketches_kll_float_sketch.sql
+++ b/sql/datasketches_kll_float_sketch.sql
@@ -71,7 +71,7 @@ CREATE OR REPLACE AGGREGATE kll_float_sketch_build(real) (
     SFUNC = kll_float_sketch_build_agg,
     COMBINEFUNC = kll_float_sketch_combine,
     SERIALFUNC = kll_float_sketch_serialize,
-    DESERIALFUNC = kll_float_sketch_deserialize, 
+    DESERIALFUNC = kll_float_sketch_deserialize,
     FINALFUNC = kll_float_sketch_finalize,
     PARALLEL = SAFE
 );
@@ -81,7 +81,7 @@ CREATE OR REPLACE AGGREGATE kll_float_sketch_build(real, int) (
     SFUNC = kll_float_sketch_build_agg,
     COMBINEFUNC = kll_float_sketch_combine,
     SERIALFUNC = kll_float_sketch_serialize,
-    DESERIALFUNC = kll_float_sketch_deserialize, 
+    DESERIALFUNC = kll_float_sketch_deserialize,
     FINALFUNC = kll_float_sketch_finalize,
     PARALLEL = SAFE
 );
@@ -91,7 +91,7 @@ CREATE OR REPLACE AGGREGATE kll_float_sketch_merge(kll_float_sketch) (
     SFUNC = kll_float_sketch_merge_agg,
     COMBINEFUNC = kll_float_sketch_combine,
     SERIALFUNC = kll_float_sketch_serialize,
-    DESERIALFUNC = kll_float_sketch_deserialize, 
+    DESERIALFUNC = kll_float_sketch_deserialize,
     FINALFUNC = kll_float_sketch_finalize,
     PARALLEL = SAFE
 );
@@ -101,7 +101,7 @@ CREATE OR REPLACE AGGREGATE kll_float_sketch_merge(kll_float_sketch, int) (
     SFUNC = kll_float_sketch_merge_agg,
     COMBINEFUNC = kll_float_sketch_combine,
     SERIALFUNC = kll_float_sketch_serialize,
-    DESERIALFUNC = kll_float_sketch_deserialize, 
+    DESERIALFUNC = kll_float_sketch_deserialize,
     FINALFUNC = kll_float_sketch_finalize,
     PARALLEL = SAFE
 );
@@ -116,6 +116,14 @@ CREATE OR REPLACE FUNCTION kll_float_sketch_get_quantile(kll_float_sketch, doubl
 
 CREATE OR REPLACE FUNCTION kll_float_sketch_get_n(kll_float_sketch) RETURNS bigint
     AS '$libdir/datasketches', 'pg_kll_float_sketch_get_n'
+    LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION kll_float_sketch_get_max_item(kll_float_sketch) RETURNS real
+    AS '$libdir/datasketches', 'pg_kll_float_sketch_get_max_item'
+    LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION kll_float_sketch_get_min_item(kll_float_sketch) RETURNS real
+    AS '$libdir/datasketches', 'pg_kll_float_sketch_get_min_item'
     LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION kll_float_sketch_to_string(kll_float_sketch) RETURNS TEXT

--- a/src/kll_double_sketch_c_adapter.cpp
+++ b/src/kll_double_sketch_c_adapter.cpp
@@ -86,6 +86,24 @@ unsigned long long kll_double_sketch_get_n(const void* sketchptr) {
   pg_unreachable();
 }
 
+double kll_double_sketch_get_max_item(const void *sketchptr) {
+    try {
+        return static_cast<const kll_double_sketch *>(sketchptr)->get_max_item();
+    } catch (std::exception &e) {
+        pg_error(e.what());
+    }
+    pg_unreachable();
+}
+
+double kll_double_sketch_get_min_item(const void *sketchptr) {
+    try {
+        return static_cast<const kll_double_sketch *>(sketchptr)->get_min_item();
+    } catch (std::exception &e) {
+        pg_error(e.what());
+    }
+    pg_unreachable();
+}
+
 char* kll_double_sketch_to_string(const void* sketchptr) {
   try {
     auto str = static_cast<const kll_double_sketch*>(sketchptr)->to_string();

--- a/src/kll_double_sketch_c_adapter.h
+++ b/src/kll_double_sketch_c_adapter.h
@@ -36,6 +36,8 @@ void kll_double_sketch_merge(void* sketchptr1, const void* sketchptr2);
 double kll_double_sketch_get_rank(const void* sketchptr, double value);
 double kll_double_sketch_get_quantile(const void* sketchptr, double rank);
 unsigned long long kll_double_sketch_get_n(const void* sketchptr);
+double kll_double_sketch_get_max_item(const void* sketchptr);
+double kll_double_sketch_get_min_item(const void* sketchptr);
 char* kll_double_sketch_to_string(const void* sketchptr);
 
 struct ptr_with_size kll_double_sketch_serialize(const void* sketchptr, unsigned header_size);

--- a/src/kll_double_sketch_pg_functions.c
+++ b/src/kll_double_sketch_pg_functions.c
@@ -35,6 +35,8 @@ PG_FUNCTION_INFO_V1(pg_kll_double_sketch_combine);
 PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_rank);
 PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_quantile);
 PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_n);
+PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_max_item);
+PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_min_item);
 PG_FUNCTION_INFO_V1(pg_kll_double_sketch_to_string);
 PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_pmf);
 PG_FUNCTION_INFO_V1(pg_kll_double_sketch_get_cdf);
@@ -50,6 +52,8 @@ Datum pg_kll_double_sketch_combine(PG_FUNCTION_ARGS);
 Datum pg_kll_double_sketch_get_rank(PG_FUNCTION_ARGS);
 Datum pg_kll_double_sketch_get_quantile(PG_FUNCTION_ARGS);
 Datum pg_kll_double_sketch_get_n(PG_FUNCTION_ARGS);
+Datum pg_kll_double_sketch_get_max_item(PG_FUNCTION_ARGS);
+Datum pg_kll_double_sketch_get_min_item(PG_FUNCTION_ARGS);
 Datum pg_kll_double_sketch_to_string(PG_FUNCTION_ARGS);
 Datum pg_kll_double_sketch_get_pmf(PG_FUNCTION_ARGS);
 Datum pg_kll_double_sketch_get_cdf(PG_FUNCTION_ARGS);
@@ -235,6 +239,28 @@ Datum pg_kll_double_sketch_get_n(PG_FUNCTION_ARGS) {
   n = kll_double_sketch_get_n(sketchptr);
   kll_double_sketch_delete(sketchptr);
   PG_RETURN_INT64(n);
+}
+
+Datum pg_kll_double_sketch_get_max_item(PG_FUNCTION_ARGS) {
+    const bytea* bytes_in;
+    void* sketchptr;
+    double value;
+    bytes_in = PG_GETARG_BYTEA_P(0);
+    sketchptr = kll_double_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
+    value = kll_double_sketch_get_max_item(sketchptr);
+    kll_double_sketch_delete(sketchptr);
+    PG_RETURN_FLOAT8(value);
+}
+
+Datum pg_kll_double_sketch_get_min_item(PG_FUNCTION_ARGS) {
+    const bytea* bytes_in;
+    void* sketchptr;
+    double value;
+    bytes_in = PG_GETARG_BYTEA_P(0);
+    sketchptr = kll_double_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
+    value = kll_double_sketch_get_min_item(sketchptr);
+    kll_double_sketch_delete(sketchptr);
+    PG_RETURN_FLOAT8(value);
 }
 
 Datum pg_kll_double_sketch_to_string(PG_FUNCTION_ARGS) {

--- a/src/kll_float_sketch_c_adapter.cpp
+++ b/src/kll_float_sketch_c_adapter.cpp
@@ -86,6 +86,24 @@ unsigned long long kll_float_sketch_get_n(const void* sketchptr) {
   pg_unreachable();
 }
 
+float kll_float_sketch_get_max_item(const void *sketchptr) {
+    try {
+        return static_cast<const kll_float_sketch *>(sketchptr)->get_max_item();
+    } catch (std::exception &e) {
+        pg_error(e.what());
+    }
+    pg_unreachable();
+}
+
+float kll_float_sketch_get_min_item(const void *sketchptr) {
+    try {
+        return static_cast<const kll_float_sketch *>(sketchptr)->get_min_item();
+    } catch (std::exception &e) {
+        pg_error(e.what());
+    }
+    pg_unreachable();
+}
+
 char* kll_float_sketch_to_string(const void* sketchptr) {
   try {
     auto str = static_cast<const kll_float_sketch*>(sketchptr)->to_string();

--- a/src/kll_float_sketch_c_adapter.h
+++ b/src/kll_float_sketch_c_adapter.h
@@ -36,6 +36,8 @@ void kll_float_sketch_merge(void* sketchptr1, const void* sketchptr2);
 double kll_float_sketch_get_rank(const void* sketchptr, float value);
 float kll_float_sketch_get_quantile(const void* sketchptr, double rank);
 unsigned long long kll_float_sketch_get_n(const void* sketchptr);
+float kll_float_sketch_get_max_item(const void* sketchptr);
+float kll_float_sketch_get_min_item(const void* sketchptr);
 char* kll_float_sketch_to_string(const void* sketchptr);
 
 struct ptr_with_size kll_float_sketch_serialize(const void* sketchptr, unsigned header_size);

--- a/src/kll_float_sketch_pg_functions.c
+++ b/src/kll_float_sketch_pg_functions.c
@@ -35,6 +35,8 @@ PG_FUNCTION_INFO_V1(pg_kll_float_sketch_combine);
 PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_rank);
 PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_quantile);
 PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_n);
+PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_max_item);
+PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_min_item);
 PG_FUNCTION_INFO_V1(pg_kll_float_sketch_to_string);
 PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_pmf);
 PG_FUNCTION_INFO_V1(pg_kll_float_sketch_get_cdf);
@@ -50,6 +52,8 @@ Datum pg_kll_float_sketch_combine(PG_FUNCTION_ARGS);
 Datum pg_kll_float_sketch_get_rank(PG_FUNCTION_ARGS);
 Datum pg_kll_float_sketch_get_quantile(PG_FUNCTION_ARGS);
 Datum pg_kll_float_sketch_get_n(PG_FUNCTION_ARGS);
+Datum pg_kll_float_sketch_get_max_item(PG_FUNCTION_ARGS);
+Datum pg_kll_float_sketch_get_min_item(PG_FUNCTION_ARGS);
 Datum pg_kll_float_sketch_to_string(PG_FUNCTION_ARGS);
 Datum pg_kll_float_sketch_get_pmf(PG_FUNCTION_ARGS);
 Datum pg_kll_float_sketch_get_cdf(PG_FUNCTION_ARGS);
@@ -235,6 +239,28 @@ Datum pg_kll_float_sketch_get_n(PG_FUNCTION_ARGS) {
   n = kll_float_sketch_get_n(sketchptr);
   kll_float_sketch_delete(sketchptr);
   PG_RETURN_INT64(n);
+}
+
+Datum pg_kll_float_sketch_get_max_item(PG_FUNCTION_ARGS) {
+    const bytea* bytes_in;
+    void* sketchptr;
+    float value;
+    bytes_in = PG_GETARG_BYTEA_P(0);
+    sketchptr = kll_float_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
+    value = kll_float_sketch_get_max_item(sketchptr);
+    kll_float_sketch_delete(sketchptr);
+    PG_RETURN_FLOAT4(value);
+}
+
+Datum pg_kll_float_sketch_get_min_item(PG_FUNCTION_ARGS) {
+    const bytea* bytes_in;
+    void* sketchptr;
+    float value;
+    bytes_in = PG_GETARG_BYTEA_P(0);
+    sketchptr = kll_float_sketch_deserialize(VARDATA(bytes_in), VARSIZE(bytes_in) - VARHDRSZ);
+    value = kll_float_sketch_get_min_item(sketchptr);
+    kll_float_sketch_delete(sketchptr);
+    PG_RETURN_FLOAT4(value);
 }
 
 Datum pg_kll_float_sketch_to_string(PG_FUNCTION_ARGS) {

--- a/test/kll_double_sketch_test.sql
+++ b/test/kll_double_sketch_test.sql
@@ -17,6 +17,8 @@ insert into kll_sketch_test
 ;
 
 -- get min and max values
+select kll_double_sketch_get_min_item(sketch) as min_item from kll_sketch_test;
+select kll_double_sketch_get_max_item(sketch) as max_item from kll_sketch_test;
 select kll_double_sketch_get_quantiles(sketch, array[0, 1]) as min_max from kll_sketch_test;
 select kll_double_sketch_to_string(sketch) from kll_sketch_test;
 

--- a/test/kll_float_sketch_test.sql
+++ b/test/kll_float_sketch_test.sql
@@ -17,6 +17,8 @@ insert into kll_sketch_test
 ;
 
 -- get min and max values
+select kll_float_sketch_get_min_item(sketch) as min_item from kll_sketch_test;
+select kll_float_sketch_get_max_item(sketch) as max_item from kll_sketch_test;
 select kll_float_sketch_get_quantiles(sketch, array[0, 1]) as min_max from kll_sketch_test;
 select kll_float_sketch_to_string(sketch) from kll_sketch_test;
 


### PR DESCRIPTION
Hi,

I noticed the get_min_item and get_max_item functions were missing from the Postgres extension for the KLL sketches. I was hoping to add them. Please let me know if this is not the correct way to do it.

Thanks!